### PR TITLE
Fix code to suppress compilation errors (for exist-db code or saxon i…

### DIFF
--- a/lib/command.xqm
+++ b/lib/command.xqm
@@ -402,7 +402,7 @@ declare function command:match-token-iter(
   (: "inherits"" attributes :)
   let $db := if ($page/@db) then $page/@db else $indb
   let $resource := if ($page/@resource) then $page/@resource else $inres
-  let $collection : = if ($page/@collection) then $page/@collection else $incol
+  let $collection := if ($page/@collection) then $page/@collection else $incol
   (:  $log := oppidum:debug(('match-token-iter with $cur', $tokens[$index], ' and $greedy=', if ($greedy) then 'true' else 'false', ' name=', string($mapping/@name), ' page=', string($page/@name))):)
   return
     if (not($last)) then
@@ -463,7 +463,7 @@ declare function command:parse-token-iter(
   (: compute inherited attributes :)
   let $db := if ($page/@db) then $page/@db else $indb
   let $resource := if ($page/@resource) then $page/@resource else $inres
-  let $collection : = if ($page/@collection) then $page/@collection else $incol
+  let $collection := if ($page/@collection) then $page/@collection else $incol
   return
     if ($page[@name = '*']) then
       (: recurse in greedy mode starting at self :)
@@ -481,6 +481,18 @@ declare function command:parse-token-iter(
       else
         command:gen-resource($method, $action, $index, $tokens, $page, $db, $resource, $collection, $confbase, $lang)
       )
+};
+
+declare function command:parse-url(
+  $base-url as xs:string,
+  $exist-root as xs:string,
+  $exist-path as xs:string,
+  $url as xs:string,
+  $method as xs:string,
+  $mapping as element(),
+  $lang as xs:string)
+{
+  command:parse-url($base-url, $exist-root, $exist-path, $url, $method, $mapping, $lang, ())
 };
 
 (: ========================================================================

--- a/lib/io.xqm
+++ b/lib/io.xqm
@@ -31,7 +31,7 @@ declare function io:gen-unique-id( $col-uri as xs:string ) as xs:integer
     else 
       max((0, 
           for $name in $files
-          let $m := text:groups($name, '^(\d+)')
+          let $m := analyze-string($name, '^(\d+)')//fn:group
           where count($m) > 0
           return xs:integer($m[2]))) + 1
 };

--- a/lib/util.xqm
+++ b/lib/util.xqm
@@ -234,7 +234,7 @@ declare function oppidum:render-error(
       if (empty($err-clue)) then
         string($msgs[1])
       else
-        string($msgs[string(@noargs) != 'yes'][1]),
+        string($msgs[string(../@noargs) != 'yes'][1]),
     $message := if ($msg) then $msg else concat("Error (", $err-type, ")"),
     $arg := if (empty($err-clue)) then '' else $err-clue,
     $text := oppidum:replace-clues($message, $arg)
@@ -307,7 +307,7 @@ declare function oppidum:render-message(
   let $msg-uri := concat($db, '/config/messages.xml')
   let $found := fn:doc($msg-uri)/messages/info[@type = $type] 
   let $candidates := if ($found/message[@lang = $lang]) then $found/message[@lang = $lang]/text() else $found/message/text()
-  let $msg := if (empty($clues)) then $candidates[1] else $candidates[string(@noargs) != 'yes'][1]
+  let $msg := if (empty($clues)) then $candidates[1] else $candidates[string(../@noargs) != 'yes'][1]
   let $src := if ($msg) then string($msg) else concat("Message (", $type, ")")
   let $arg := if (empty($clues)) then '' else $clues
   let $text := oppidum:replace-clues($src, $arg)

--- a/modules/benchmark/fibonacci.xql
+++ b/modules/benchmark/fibonacci.xql
@@ -39,7 +39,7 @@ let $max := request:get-parameter('max', 10)
 return
   if ($max castable as xs:integer) then
     if ((number($max) > 0) and (number($max) < 1000)) then 
-      let $results := local:fibonacci(number($max))
+      let $results := local:fibonacci(xs:integer(number($max)))
       let $free-after := system:get-memory-free()
       let $end := util:system-time()
       let $runtimems := (($end - $start) div xs:dayTimeDuration('PT1S'))  * 1000

--- a/modules/localization/dictionary.xql
+++ b/modules/localization/dictionary.xql
@@ -44,7 +44,7 @@ declare function local:check-csv( $languages as xs:string*, $uri as xs:string ) 
 };
 
 declare function local:timestamp() {
-  let $date := current-dateTime()
+  let $date := string(current-dateTime())
   return
     concat(
       substring($date,9,2), '/', substring($date,6,2), '/', substring($date,1,4),

--- a/test/rights.xql
+++ b/test/rights.xql
@@ -35,7 +35,7 @@ declare variable $mapping := <site db="/db/aed" startref="home" supported="login
 declare function local:test-rights( $nb as xs:integer, $payload as xs:string, $method as xs:string, $access as element()?) 
 {
   let 
-    $cmd := command:parse-url('BASE', 'ROOT', $payload, $method, $mapping, 'fr', ()),
+    $cmd := command:parse-url('BASE', 'ROOT', 'PATH', $payload, $method, $mapping, 'fr', ()),
     $rights := oppidum:get-rights-for($cmd, $access)
   
   return 
@@ -45,7 +45,7 @@ declare function local:test-rights( $nb as xs:integer, $payload as xs:string, $m
 declare function local:test-access( $nb as xs:integer, $payload as xs:string, $method as xs:string, $access as element()?) 
 {
   let 
-    $cmd := command:parse-url('BASE', 'ROOT', $payload, $method, $mapping, 'fr', ()),
+    $cmd := command:parse-url('BASE', 'ROOT', 'PATH', $payload, $method, $mapping, 'fr', ()),
     $granted := oppidum:check-rights-for($cmd, $access),
     $msg := string-join(oppidum:get-errors(), ' ')
     


### PR DESCRIPTION
Fix code to suppress compilation errors (for exist-db code or saxon implementation version).
Contains :

- update to follow the XQuery Spec
- remove of deprecated code
- fix of real exist-db issues

Allow to get valid XQuery code usable with Saxon processor : usefull to compil XQuery directly under Oxygen and launch/debug it with local data (not in database)
